### PR TITLE
Show text instead of description

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Show ShopItem text instead of the description.
+  This is consistent to other block types.
+  [mathias.leimgruber]
 
 
 1.1.3 (2014-08-12)

--- a/ftwshop/simplelayout/browser/shopitemblock.pt
+++ b/ftwshop/simplelayout/browser/shopitemblock.pt
@@ -17,7 +17,7 @@
                         <img tal:replace="structure view/get_image_tag" />
                     </a>
         </div>
-        <div tal:content="item/description"></div>
+        <div tal:condition="context/getItem | nothing" tal:content="structure python: context.getItem().getText()"></div>
 
             <!-- Single Item, no variations -->
             <div tal:condition="not:item/hasVariations"


### PR DESCRIPTION
Others block types also show the text, not the description. 

@jone 
